### PR TITLE
Add Salesforce composable storefront PWA demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@
                                 <div class="descrp">
                                     <p>Perform an online payment using sessions</p>
                                     <div class="links_list">
-                                        <a 
+                                        <a target="_blank" rel="noopener"
                                             class="a_icon devicon-java-plain colored"
                                             href="https://github.com/adyen-examples/adyen-java-spring-online-payments/tree/main/checkout-example"
                                             data-track-section-title="implementation examples" 
@@ -121,7 +121,7 @@
                                             title="Java Spring sessions implementation" 
                                             >
                                         </a>
-                                        <a 
+                                        <a target="_blank" rel="noopener"
                                             class="a_icon devicon-dot-net-plain colored"
                                             href="https://github.com/adyen-examples/adyen-dotnet-online-payments/tree/main/checkout-example"
                                             data-track-section-title="implementation examples" 
@@ -132,7 +132,7 @@
                                             title="DotNet sessions implementation"                                       
                                             >
                                         </a>
-                                        <a 
+                                        <a target="_blank" rel="noopener"
                                             class="a_icon devicon-nodejs-plain colored"
                                             href="https://github.com/adyen-examples/adyen-node-online-payments/tree/main/checkout-example"
                                             data-track-section-title="implementation examples" 
@@ -143,7 +143,7 @@
                                             title="NodeJS sessions implementation"                                           
                                             >
                                         </a>                                        
-                                        <a 
+                                        <a target="_blank" rel="noopener"
                                             class="a_icon devicon-vuejs-plain colored"
                                             href="https://github.com/adyen-examples/adyen-vue-online-payments"
                                             data-track-section-title="implementation examples" 
@@ -154,7 +154,7 @@
                                             title="VueJS sessions implementation"                                            
                                             >
                                         </a>  
-                                        <a 
+                                        <a target="_blank" rel="noopener"
                                             class="a_icon devicon-react-original colored"
                                             href="https://github.com/adyen-examples/adyen-react-online-payments"
                                             data-track-section-title="implementation examples" 
@@ -165,7 +165,7 @@
                                             title="ReactJS sessions implementation"                                            
                                             >
                                         </a>          
-                                        <a 
+                                        <a target="_blank" rel="noopener"
                                             class="a_icon devicon-angularjs-plain colored"
                                             href="https://github.com/adyen-examples/adyen-angular-online-payments"
                                             data-track-section-title="implementation examples" 
@@ -176,7 +176,7 @@
                                             title="AngularJS sessions implementation"                                         
                                             >
                                         </a>             
-                                        <a 
+                                        <a target="_blank" rel="noopener"
                                             class="a_icon devicon-android-plain colored"
                                             href="https://github.com/adyen-examples/adyen-android-online-payments"
                                             data-track-section-title="implementation examples" 
@@ -187,7 +187,7 @@
                                             title="Android sessions implementation"                                       
                                             >
                                         </a>                                                                         
-                                        <a 
+                                        <a target="_blank" rel="noopener"
                                             class="a_icon devicon-rails-plain colored"
                                             href="https://github.com/adyen-examples/adyen-rails-online-payments"
                                             data-track-section-title="implementation examples" 
@@ -198,7 +198,7 @@
                                             title="Rails sessions implementation"                                            
                                             >
                                         </a>       
-                                        <a 
+                                        <a target="_blank" rel="noopener"
                                             class="a_icon devicon-python-plain colored"
                                             href="https://github.com/adyen-examples/adyen-python-online-payments"
                                             data-track-section-title="implementation examples" 
@@ -209,7 +209,7 @@
                                             title="Python sessions implementation"                                              
                                             >
                                         </a>      
-                                        <a 
+                                        <a target="_blank" rel="noopener"
                                             class="a_icon devicon-go-original-wordmark colored"
                                             href="https://github.com/adyen-examples/adyen-golang-online-payments"
                                             data-track-section-title="implementation examples" 
@@ -220,7 +220,7 @@
                                             title="Golang sessions implementation"                                               
                                         >
                                         </a>                         
-                                        <a 
+                                        <a target="_blank" rel="noopener"
                                             class="a_icon devicon-laravel-plain colored"
                                             href="https://github.com/adyen-examples/adyen-php-online-payments"
                                             data-track-section-title="implementation examples" 
@@ -231,7 +231,7 @@
                                             title="Laravel sessions implementation"                                             
                                             >
                                         </a>            
-                                        <a 
+                                        <a target="_blank" rel="noopener"
                                             class="a_icon devicon-kotlin-plain colored"
                                             href="https://github.com/adyen-examples/adyen-kotlin-spring-online-payments"
                                             data-track-section-title="implementation examples" 
@@ -258,7 +258,7 @@
                                 <div class="descrp">
                                     <p>Perform a complex online payment in three steps</p>
                                     <div class="links_list">
-                                        <a
+                                        <a target="_blank" rel="noopener"
                                             class="a_icon devicon-java-plain colored"
                                             href="https://github.com/adyen-examples/adyen-java-spring-online-payments/tree/main/checkout-example-advanced"
                                             data-track-section-title="implementation examples" 
@@ -269,7 +269,7 @@
                                             title="Java Spring complex implementation"                                              
                                             >
                                         </a>
-                                        <a 
+                                        <a target="_blank" rel="noopener"
                                             class="a_icon devicon-dot-net-plain colored"
                                             href="https://github.com/adyen-examples/adyen-dotnet-online-payments/tree/main/checkout-example-advanced"
                                             data-track-section-title="implementation examples" 
@@ -280,7 +280,7 @@
                                             title="DotNet complex implementation"                                   
                                             >
                                         </a>
-                                        <a 
+                                        <a target="_blank" rel="noopener"
                                             class="a_icon devicon-nodejs-plain colored"
                                             href="https://github.com/adyen-examples/adyen-node-online-payments/tree/main/checkout-example-advanced"
                                             data-track-section-title="implementation examples" 
@@ -307,7 +307,7 @@
                                     <p>Connect your existing E-commerce system to our payments platform.</p>
                                     <div class="links_list">
 
-                                        <a 
+                                        <a target="_blank" rel="noopener"
                                             class="a_icon devicon-magento-original colored"
                                             href="https://github.com/adyen-examples/adyen-magento-plugin-demo"
                                             data-track-section-title="implementation examples" 
@@ -318,7 +318,7 @@
                                             title="Magento payments plugin implementation"                                              
                                             >
                                         </a>     
-                                        <a 
+                                        <a target="_blank" rel="noopener"
                                             class="a_icon devicon-shopware-original colored"
                                             href="https://github.com/adyen-examples/adyen-shopware-plugin-demo"
                                             data-track-section-title="implementation examples" 
@@ -329,15 +329,15 @@
                                             title="Shopware payments plugin implementation"                                              
                                             >
                                         </a>
-                                        <a 
+                                        <a target="_blank" rel="noopener"
                                             class="a_icon devicon-salesforce-plain colored"
-                                            href="https://github.com/adyen-examples/adyen-shopware-plugin-demo"
+                                            href="https://github.com/adyen-examples/adyen-salesforce-pwa-headless-demo"
                                             data-track-section-title="implementation examples" 
                                             data-track-component-name="card_item" 
                                             data-track-action="clicked" data-track-type="card_item"
-                                            data-track-title="Shopware payments plugin implementation" 
-                                            data-track-text="Perform online payments using Adyen plugin for Shopware"  
-                                            title="Shopware payments plugin implementation"                                              
+                                            data-track-title="Salesforce composable storefront implementation" 
+                                            data-track-text="Perform online payments using Adyen plugin for Salesforce composable storefront - PWA"  
+                                            title="Salesforce composable storefront implementation"                                              
                                             >
                                         </a>            
                                     </div>                                                                                                                                                                                    
@@ -355,7 +355,7 @@
                                 <div class="descrp">
                                     <p>Tokenize card details and perform a merchant initiated transaction</p>
                                     <div class="links_list">
-                                        <a
+                                        <a target="_blank" rel="noopener"
                                             class="a_icon devicon-java-plain colored"
                                             href="https://github.com/adyen-examples/adyen-java-spring-online-payments/tree/main/subscription-example"
                                             data-track-section-title="implementation examples" 
@@ -366,7 +366,7 @@
                                             title="Java Spring subscriptions implementation"                                             
                                             >
                                         </a>
-                                        <a 
+                                        <a target="_blank" rel="noopener"
                                             class="a_icon devicon-dot-net-plain colored"
                                             href="https://github.com/adyen-examples/adyen-dotnet-online-payments/tree/main/subscription-example"
                                             data-track-section-title="implementation examples" 
@@ -377,7 +377,7 @@
                                             title="DotNet subscriptions implementation"                                 
                                             >
                                         </a>
-                                        <a 
+                                        <a target="_blank" rel="noopener"
                                             class="a_icon devicon-nodejs-plain colored"
                                             href="https://github.com/adyen-examples/adyen-node-online-payments/tree/main/subscription-example"
                                             data-track-section-title="implementation examples" 
@@ -403,7 +403,7 @@
                                 <div class="descrp">
                                     <p>Perform partial payments using gift cards</p>
                                     <div class="links_list">
-                                        <a
+                                        <a target="_blank" rel="noopener"
                                             class="a_icon devicon-java-plain colored"
                                             href="https://github.com/adyen-examples/adyen-java-spring-online-payments/tree/main/giftcard-example"
                                             data-track-section-title="implementation examples" 
@@ -414,7 +414,7 @@
                                             title="Java Spring Gift Cards implementation"                              
                                             >
                                         </a>
-                                        <a 
+                                        <a target="_blank" rel="noopener"
                                             class="a_icon devicon-dot-net-plain colored"
                                             href="https://github.com/adyen-examples/adyen-dotnet-online-payments/tree/main/giftcard-example"
                                             data-track-section-title="implementation examples" 
@@ -425,7 +425,7 @@
                                             title="DotNet Gift Cards implementation"                                 
                                             >
                                         </a>
-                                        <a 
+                                        <a target="_blank" rel="noopener"
                                             class="a_icon devicon-nodejs-plain colored"
                                             href="https://github.com/adyen-examples/adyen-node-online-payments/tree/main/giftcard-example"
                                             data-track-section-title="implementation examples" 
@@ -451,7 +451,7 @@
                                 <div class="descrp">
                                     <p>Create and manage payment links</p>
                                     <div class="links_list">
-                                        <a
+                                        <a target="_blank" rel="noopener"
                                             class="a_icon devicon-java-plain colored"
                                             href="https://github.com/adyen-examples/adyen-java-spring-online-payments/tree/main/paybylink-example"
                                             data-track-section-title="implementation examples" 
@@ -462,7 +462,7 @@
                                             title="Java Spring Payment Links implementation"                                  
                                             >
                                         </a>
-                                        <a 
+                                        <a target="_blank" rel="noopener"
                                             class="a_icon devicon-dot-net-plain colored" 
                                             href="https://github.com/adyen-examples/adyen-dotnet-online-payments/tree/main/paybylink-example"
                                             data-track-section-title="implementation examples" 
@@ -473,7 +473,7 @@
                                             title="DotNet Payment Links implementation"                                
                                             >
                                         </a>
-                                        <a 
+                                        <a target="_blank" rel="noopener"
                                             class="a_icon devicon-nodejs-plain colored"
                                             href="https://github.com/adyen-examples/adyen-node-online-payments/tree/main/paybylink-example"
                                             data-track-section-title="implementation examples" 
@@ -499,7 +499,7 @@
                                 <div class="descrp">
                                     <p>Pre-authorise payments, adjust the amount and capture, cancel or refund the payment</p>
                                     <div class="links_list">
-                                        <a
+                                        <a target="_blank" rel="noopener"
                                                 class="a_icon devicon-java-plain colored"
                                                 href="https://github.com/adyen-examples/adyen-java-spring-online-payments/tree/main/authorisation-adjustment-example"
                                                 data-track-section-title="implementation examples"
@@ -510,7 +510,7 @@
                                                 title="Java Authorisation Adjustment implementation"
                                         >
                                         </a>
-                                        <a
+                                        <a target="_blank" rel="noopener"
                                             class="a_icon devicon-dot-net-plain colored"
                                             href="https://github.com/adyen-examples/adyen-dotnet-online-payments/tree/main/authorisation-adjustment-example"
                                             data-track-section-title="implementation examples"
@@ -521,7 +521,7 @@
                                             title="DotNet Authorisation Adjustment implementation"
                                         >
                                         </a>
-                                        <a 
+                                        <a target="_blank" rel="noopener"
                                             class="a_icon devicon-nodejs-plain colored"
                                             href="https://github.com/adyen-examples/adyen-node-online-payments/tree/main/authorisation-adjustment-example"
                                             data-track-section-title="implementation examples" 
@@ -547,7 +547,7 @@
                                 <div class="descrp">
                                     <p>Give your shoppers the option to donate to a charity as part of your payment flow.</p>
                                     <div class="links_list">
-                                        <a
+                                        <a target="_blank" rel="noopener"
                                             class="a_icon devicon-java-plain colored"
                                             href="https://github.com/adyen-examples/adyen-java-spring-online-payments/tree/main/giving-example"
                                             data-track-section-title="implementation examples" 
@@ -558,7 +558,7 @@
                                             title="Java Spring Adyen Giving implementation"                                  
                                             >
                                         </a>
-                                        <a
+                                        <a target="_blank" rel="noopener"
                                             class="a_icon devicon-dot-net-plain colored"
                                             href="https://github.com/adyen-examples/adyen-dotnet-online-payments/tree/main/giving-example"
                                             data-track-section-title="implementation examples"
@@ -569,7 +569,7 @@
                                             title="DotNet Adyen Giving implementation"
                                         >
                                         </a>
-                                        <a
+                                        <a target="_blank" rel="noopener"
                                             class="a_icon devicon-nodejs-plain colored"
                                             href="https://github.com/adyen-examples/adyen-node-online-payments/tree/main/giving-example"
                                             data-track-section-title="implementation examples"
@@ -595,7 +595,7 @@
                                 <div class="descrp">
                                     <p>Perform either a Native or Redirect 3DS2 Authentication</p>
                                     <div class="links_list">
-                                        <a
+                                        <a target="_blank" rel="noopener"
                                                 class="a_icon devicon-nodejs-plain colored"
                                                 href="https://github.com/adyen-examples/adyen-node-online-payments/tree/main/3ds2-example"
                                                 data-track-section-title="implementation examples"
@@ -621,7 +621,7 @@
                                 <div class="descrp">
                                     <p>Make payment, reversal, abort and transaction-status requests to a POS terminal.</p>
                                     <div class="links_list">
-                                        <a
+                                        <a target="_blank" rel="noopener"
                                             class="a_icon devicon-java-plain colored"
                                             href="https://github.com/adyen-examples/adyen-java-spring-online-payments/tree/main/in-person-payments-example"
                                             data-track-section-title="implementation examples"
@@ -632,7 +632,7 @@
                                             title="Java In-person Payments implementation"
                                         >
                                         </a>
-                                        <a
+                                        <a target="_blank" rel="noopener"
                                             class="a_icon devicon-dot-net-plain colored"
                                             href="https://github.com/adyen-examples/adyen-dotnet-online-payments/tree/main/in-person-payments-example"
                                             data-track-section-title="implementation examples"
@@ -643,7 +643,7 @@
                                             title="DotNet In-person Payments implementation"
                                         >
                                         </a>
-                                        <a
+                                        <a target="_blank" rel="noopener"
                                             class="a_icon devicon-nodejs-plain colored"
                                             href="https://github.com/adyen-examples/adyen-node-online-payments/tree/main/in-person-payments-example"
                                             data-track-section-title="implementation examples"
@@ -669,7 +669,7 @@
                                 <div class="descrp">
                                     <p>Make card acquisition requests to a POS terminal.</p>
                                     <div class="links_list">
-                                        <a
+                                        <a target="_blank" rel="noopener"
                                                 class="a_icon devicon-dot-net-plain colored"
                                                 href="https://github.com/adyen-examples/adyen-dotnet-online-payments/tree/main/in-person-payments-loyalty-example"
                                                 data-track-section-title="implementation examples"
@@ -695,7 +695,7 @@
                                 <div class="descrp">
                                     <p>Onboard users of your platform or marketplace, process payments and payouts.</p>
                                     <div class="links_list">
-                                        <a
+                                        <a target="_blank" rel="noopener"
                                             class="a_icon devicon-java-plain colored"
                                             href="https://github.com/adyen-examples/adyen-afp-sample"
                                             data-track-section-title="implementation examples"


### PR DESCRIPTION
This PR:

- [x] Adds the Salesforce Composable Storefront (PWA) demo to Plugins integration-examples
- [x] Updates all links to open in a new tab.