### PR TITLE
Add required header security policies

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,0 +1,6 @@
+/*
+  Strict-Transport-Security: max-age=31536000; includeSubDomains
+  Content-Security-Policy: default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; frame-ancestors 'self'; form-action 'self';
+  X-Frame-Options: deny
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: no-referrer


### PR DESCRIPTION
This PR adds required security headers to the website to comply with security best practices.

**Changes:**
- Added a `_headers` file to the root directory.
- Implemented the following security headers:
  - `Strict-Transport-Security` with `max-age=31536000; includeSubDomains`
  - `Content-Security-Policy` with restrictive policies.
  - `X-Frame-Options` set to `deny`.
  - `X-Content-Type-Options` set to `nosniff`.
  - `Referrer-Policy` set to `no-referrer`.

**Scan result**
<img width="1144" alt="Screenshot 2024-09-20 at 11 24 56" src="https://github.com/user-attachments/assets/975fecdd-771c-4b8e-9f47-78132054ea24">