### PR TITLE
Move inline scripts and create allow list

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,6 +1,6 @@
 /*
   Strict-Transport-Security: max-age=31536000; includeSubDomains
-  Content-Security-Policy: default-src 'none'; script-src 'self' https://www.googletagmanager.com; connect-src 'self'; img-src 'self' https://*.adyen.com; style-src 'self' https://*.adyen.com http://w3.org; frame-ancestors 'self'; form-action 'self';
+  Content-Security-Policy: default-src 'none'; script-src 'self' https://www.googletagmanager.com; connect-src 'self' https://google-analytics.com; img-src 'self' https://adyen.com; style-src 'self' https://adyen.com http://w3.org; frame-ancestors 'self'; frame-src 'self' https://app.netlify.com;  form-action 'self';
   X-Frame-Options: deny
   X-Content-Type-Options: nosniff
   Referrer-Policy: no-referrer

--- a/_headers
+++ b/_headers
@@ -1,6 +1,6 @@
 /*
   Strict-Transport-Security: max-age=31536000; includeSubDomains
-  Content-Security-Policy: default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; frame-ancestors 'self'; form-action 'self';
+  Content-Security-Policy: default-src 'none'; script-src 'self' https://googletagmanager.com; connect-src 'self'; img-src 'self' https://*.adyen.com; style-src 'self' https://*.adyen.com http://w3.org; frame-ancestors 'self'; form-action 'self';
   X-Frame-Options: deny
   X-Content-Type-Options: nosniff
   Referrer-Policy: no-referrer

--- a/_headers
+++ b/_headers
@@ -1,6 +1,6 @@
 /*
   Strict-Transport-Security: max-age=31536000; includeSubDomains
-  Content-Security-Policy: default-src 'none'; script-src 'self' https://googletagmanager.com; connect-src 'self'; img-src 'self' https://*.adyen.com; style-src 'self' https://*.adyen.com http://w3.org; frame-ancestors 'self'; form-action 'self';
+  Content-Security-Policy: default-src 'none'; script-src 'self' https://www.googletagmanager.com; connect-src 'self'; img-src 'self' https://*.adyen.com; style-src 'self' https://*.adyen.com http://w3.org; frame-ancestors 'self'; form-action 'self';
   X-Frame-Options: deny
   X-Content-Type-Options: nosniff
   Referrer-Policy: no-referrer

--- a/_headers
+++ b/_headers
@@ -1,6 +1,6 @@
 /*
   Strict-Transport-Security: max-age=31536000; includeSubDomains
-  Content-Security-Policy: default-src 'none'; script-src 'self' https://www.googletagmanager.com; connect-src 'self' https://google-analytics.com; img-src 'self' https://adyen.com; style-src 'self' https://adyen.com http://w3.org; frame-ancestors 'self'; frame-src 'self' https://app.netlify.com;  form-action 'self';
+  Content-Security-Policy: default-src 'none'; script-src 'self' https://www.googletagmanager.com; connect-src 'self' https://*.google-analytics.com; img-src 'self' https://*.adyen.com; style-src 'self' https://*.adyen.com http://w3.org; frame-ancestors 'self'; frame-src 'self' https://app.netlify.com;  form-action 'self';
   X-Frame-Options: deny
   X-Content-Type-Options: nosniff
   Referrer-Policy: no-referrer

--- a/index.html
+++ b/index.html
@@ -26,9 +26,7 @@
     <script src="js/main.js"></script>
     
     <!-- Google Tag Manager --> 
-    <script>
-    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','GTM-NRVX4WG');
-    </script> 
+    <script src="js/tm-gtag.js"></script> 
 </head>
 <body>
     <!-- Google Tag Manager (noscript) -->
@@ -1167,13 +1165,6 @@
 
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-96FYZ2QBE7"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-96FYZ2QBE7');
-    </script>
 
 </body>
 </html>

--- a/js/tm-gtag.js
+++ b/js/tm-gtag.js
@@ -1,0 +1,22 @@
+// Google Tag Manager
+(function(w, d, s, l, i) {
+    w[l] = w[l] || [];
+    w[l].push({
+        'gtm.start': new Date().getTime(),
+        event: 'gtm.js'
+    });
+    var f = d.getElementsByTagName(s)[0],
+        j = d.createElement(s),
+        dl = l != 'dataLayer' ? '&l=' + l : '';
+    j.async = true;
+    j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+    f.parentNode.insertBefore(j, f);
+})(window, document, 'script', 'dataLayer', 'GTM-NRVX4WG');
+
+// Google Analytics gtag.js
+window.dataLayer = window.dataLayer || [];
+function gtag() {
+    dataLayer.push(arguments);
+}
+gtag('js', new Date());
+gtag('config', 'G-96FYZ2QBE7');

--- a/newsletter-archive/index.html
+++ b/newsletter-archive/index.html
@@ -187,7 +187,7 @@
                                     
                                     <div class="newsletter_links_list">
                                         <a target="_blank"
-                                           href="2024/08.html"
+                                           href="2024/09.html"
                                            data-track-section-title="newsletter archive"
                                            data-track-component-name="card_item"
                                            data-track-action="clicked" data-track-type="card_item"


### PR DESCRIPTION
In this PR:

- Moved all the inline scripts to an external file as per Content Security Policy requirements
- Created an allow-list for `style-src` , `img-src` , and `script-src` as per Content Security Policy requirements