### PR TITLE
Fix broken Tech Blog link

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,38 +1,43 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <!-- Metas -->
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="All developer focused solutions in one place. Learn how to best integrate with Adyen. Code samples, blogs and much more..." />
+    <meta name="description"
+        content="All developer focused solutions in one place. Learn how to best integrate with Adyen. Code samples, blogs and much more..." />
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Adyen Devs" />
-    <meta name="twitter:description" content="All developer focused solutions in one place. Learn how to best integrate with Adyen. Code samples, blogs and much more..." />
+    <meta name="twitter:description"
+        content="All developer focused solutions in one place. Learn how to best integrate with Adyen. Code samples, blogs and much more..." />
     <meta name="twitter:image" content="https://developers.adyen.com/img/social-preview.png" />
 
     <meta property="og:title" content="Adyen Devs" />
-    <meta property="og:description" content="All developer focused solutions in one place. Learn how to best integrate with Adyen. Code samples, blogs and much more..." />
+    <meta property="og:description"
+        content="All developer focused solutions in one place. Learn how to best integrate with Adyen. Code samples, blogs and much more..." />
     <meta property="og:image" content="https://developers.adyen.com/img/social-preview.png" />
 
     <!-- Links -->
     <link rel="stylesheet" href="css/styles.css">
     <link rel="icon" type="image/png" sizes="192x192" href="img/adyen-icon-192x192.png">
-    
+
     <title>Adyen Devs</title>
 
 
     <script src="js/main.js"></script>
-    
-    <!-- Google Tag Manager --> 
-    <script src="js/tm-gtag.js"></script> 
+
+    <!-- Google Tag Manager -->
+    <script src="js/tm-gtag.js"></script>
 </head>
+
 <body>
     <!-- Google Tag Manager (noscript) -->
     <noscript>
-        <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NRVX4WG"
-        height="0" width="0" style="display:none;visibility:hidden">
+        <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NRVX4WG" height="0" width="0"
+            style="display:none;visibility:hidden">
         </iframe>
     </noscript>
     <!-- End Google Tag Manager (noscript) -->
@@ -42,49 +47,63 @@
         <div class="container">
             <a href="" class="header_logo">
                 <!-- Increase the width to 250 to contain the text 'DEVELOPERS' -->
-                <svg width="170" height="30" enable-background="new 0 0 170 30" viewBox="0 0 170 30" xmlns="http://www.w3.org/2000/svg">
+                <svg width="170" height="30" enable-background="new 0 0 170 30" viewBox="0 0 170 30"
+                    xmlns="http://www.w3.org/2000/svg">
                     <!-- Increase the width to 110 to contain the text 'DEVELOPERS' -->
                     <rect y="0" x="100" width="60" height="30" rx="8" fill="#E6F8ED"></rect>
                     <g fill="#0abf53">
-                        <path d="M12.7406 7.0246H0.200639V11.0374H8.32652C8.82812 11.0374 9.22939 11.4387 9.22939 11.9403V18.9626H7.52396C7.02236 18.9626 6.62109 18.5613 6.62109 18.0597V13.0438H3.21022C1.40447 13.0438 0 14.4482 0 16.254V19.8655C0 21.6712 1.40447 23.0757 3.21022 23.0757H15.9508V10.2348C15.9508 8.42907 14.5463 7.0246 12.7406 7.0246V7.0246Z" fill="#0ABF53"></path>
-                        <path d="M27.8888 18.9626H26.1834C25.6818 18.9626 25.2805 18.5613 25.2805 18.0597V7.02459H21.8696C20.0639 7.02459 18.6594 8.42906 18.6594 10.2348V19.7652C18.6594 21.5709 20.0639 22.9754 21.8696 22.9754H34.6102V0.403503H27.9891L27.8888 18.9626Z" fill="#0ABF53"></path>
-                        <path d="M46.4479 18.9626H44.7425C44.2409 18.9626 43.8396 18.5613 43.8396 18.0597V7.0246H37.2185V19.7652C37.2185 21.5709 38.623 22.9754 40.4287 22.9754H46.5482V24.9818H37.5195V29.5965H50.0594C51.8652 29.5965 53.2696 28.192 53.2696 26.3863V7.0246H46.6485V18.9626H46.4479Z" fill="#0ABF53"></path>
-                        <path d="M68.5182 7.0246H55.7776V19.7652C55.7776 21.5709 57.1821 22.9754 58.9879 22.9754H71.5278V18.9626H63.4019C62.9003 18.9626 62.4991 18.5613 62.4991 18.0597V11.0374H64.2045C64.7061 11.0374 65.1074 11.4387 65.1074 11.9403V16.9562H68.5182C70.324 16.9562 71.7284 15.5518 71.7284 13.746V10.2348C71.7284 8.42907 70.2237 7.0246 68.5182 7.0246V7.0246Z" fill="#0ABF53"></path>
-                        <path d="M87.0773 7.0246H74.3367V22.9754H80.9578V11.0374H82.6633C83.1648 11.0374 83.5661 11.4387 83.5661 11.9403V22.9754H90.2875V10.2348C90.2875 8.42907 88.8831 7.0246 87.0773 7.0246V7.0246Z" fill="#0ABF53"></path>
+                        <path
+                            d="M12.7406 7.0246H0.200639V11.0374H8.32652C8.82812 11.0374 9.22939 11.4387 9.22939 11.9403V18.9626H7.52396C7.02236 18.9626 6.62109 18.5613 6.62109 18.0597V13.0438H3.21022C1.40447 13.0438 0 14.4482 0 16.254V19.8655C0 21.6712 1.40447 23.0757 3.21022 23.0757H15.9508V10.2348C15.9508 8.42907 14.5463 7.0246 12.7406 7.0246V7.0246Z"
+                            fill="#0ABF53"></path>
+                        <path
+                            d="M27.8888 18.9626H26.1834C25.6818 18.9626 25.2805 18.5613 25.2805 18.0597V7.02459H21.8696C20.0639 7.02459 18.6594 8.42906 18.6594 10.2348V19.7652C18.6594 21.5709 20.0639 22.9754 21.8696 22.9754H34.6102V0.403503H27.9891L27.8888 18.9626Z"
+                            fill="#0ABF53"></path>
+                        <path
+                            d="M46.4479 18.9626H44.7425C44.2409 18.9626 43.8396 18.5613 43.8396 18.0597V7.0246H37.2185V19.7652C37.2185 21.5709 38.623 22.9754 40.4287 22.9754H46.5482V24.9818H37.5195V29.5965H50.0594C51.8652 29.5965 53.2696 28.192 53.2696 26.3863V7.0246H46.6485V18.9626H46.4479Z"
+                            fill="#0ABF53"></path>
+                        <path
+                            d="M68.5182 7.0246H55.7776V19.7652C55.7776 21.5709 57.1821 22.9754 58.9879 22.9754H71.5278V18.9626H63.4019C62.9003 18.9626 62.4991 18.5613 62.4991 18.0597V11.0374H64.2045C64.7061 11.0374 65.1074 11.4387 65.1074 11.9403V16.9562H68.5182C70.324 16.9562 71.7284 15.5518 71.7284 13.746V10.2348C71.7284 8.42907 70.2237 7.0246 68.5182 7.0246V7.0246Z"
+                            fill="#0ABF53"></path>
+                        <path
+                            d="M87.0773 7.0246H74.3367V22.9754H80.9578V11.0374H82.6633C83.1648 11.0374 83.5661 11.4387 83.5661 11.9403V22.9754H90.2875V10.2348C90.2875 8.42907 88.8831 7.0246 87.0773 7.0246V7.0246Z"
+                            fill="#0ABF53"></path>
                     </g>
                     <!-- Text -->
-                    <text font-weight="bold" xml:space="preserve" text-anchor="start" font-family="Fakt, Arial, sans-serif" font-size="13" y="20" x="110" stroke-width="0" fill="#09ae4c">DEVS</text>
+                    <text font-weight="bold" xml:space="preserve" text-anchor="start"
+                        font-family="Fakt, Arial, sans-serif" font-size="13" y="20" x="110" stroke-width="0"
+                        fill="#09ae4c">DEVS</text>
                 </svg>
             </a>
 
         </div>
     </header>
     <!-- Header ends -->
-    
+
     <main class="">
         <!-- Hero starts -->
         <section class="hero">
             <div class="container ls_flex_content">
                 <div class="ls_flex_details">
-                  <h1 class="ls_flex_details_title">
-                   Adyen 💚 Devs
-                  </h1>
-                  <p class="ds-text-medium"> Developer-focused solutions in one place: Integrate seamlessly with Adyen using our integration examples, tools, blogs, and more! Stay updated with our API, libraries, and upcoming events...</p> <br />
-                 
-                  <button class="btn prim_btn">
-                    <a target="_blank" rel="noopener" href="https://www.adyen.com/newsletter/developers?utm_medium=referral&utm_source=developers.adyen.com">&#128229; Sign up for the Developer Newsletter 
-                    </a>
-                  </button>
+                    <h1 class="ls_flex_details_title">
+                        Adyen 💚 Devs
+                    </h1>
+                    <p class="ds-text-medium"> Developer-focused solutions in one place: Integrate seamlessly with Adyen
+                        using our integration examples, tools, blogs, and more! Stay updated with our API, libraries,
+                        and upcoming events...</p> <br />
+
+                    <button class="btn prim_btn">
+                        <a target="_blank" rel="noopener"
+                            href="https://www.adyen.com/newsletter/developers?utm_medium=referral&utm_source=developers.adyen.com">&#128229;
+                            Sign up for the Developer Newsletter
+                        </a>
+                    </button>
 
                 </div>
                 <div class="ls_flex_img">
-                  <img
-                    src="img/adyen-devs-illustration-v3.svg"
-                    alt="image"
-                  />
+                    <img src="img/adyen-devs-illustration-v3.svg" alt="image" />
                 </div>
-                
-              </div>
+
+            </div>
         </section>
         <!-- Hero ends -->
 
@@ -100,7 +119,7 @@
                 <div class="card">
                     <!-- Online Payments (sessions) -->
                     <div class="card_item card_item_box_shadow_small">
-                        <div class="card_item_top" >
+                        <div class="card_item_top">
                             <div class="content">
                                 <img src="icons/github.svg" alt="" class="icon">
                                 <h5 class="title">Online Payments</h5>
@@ -110,44 +129,44 @@
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-java-spring-online-payments/tree/main/checkout-example"
-                                                data-track-section-title="implementation examples" 
-                                                data-track-component-name="card_item" 
-                                                data-track-action="clicked" data-track-type="card_item"
-                                                data-track-title="java spring sessions implementation" 
-                                                data-track-text="Performing an online payment using sessions with Java" 
-                                                title="Java Spring sessions implementation" 
-                                                >
-                                                <img src="icons/languages/java-original.svg" alt="Java Icon" class="a_icon"/>
+                                                data-track-section-title="implementation examples"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
+                                                data-track-title="java spring sessions implementation"
+                                                data-track-text="Performing an online payment using sessions with Java"
+                                                title="Java Spring sessions implementation">
+                                                <img src="icons/languages/java-original.svg" alt="Java Icon"
+                                                    class="a_icon" />
                                                 <div class="icon-text">Java</div>
                                             </a>
                                         </div>
-                                        
+
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-dotnet-online-payments/tree/main/checkout-example"
-                                                data-track-section-title="implementation examples" 
-                                                data-track-component-name="card_item" 
-                                                data-track-action="clicked" data-track-type="card_item"
-                                                data-track-title="dotnet sessions implementation" 
-                                                data-track-text="Performing an online payment using sessions with Dotnet"       
-                                                title="DotNet sessions implementation"                                       
-                                                >
-                                                <img src="icons/languages/dot-net-original.svg" alt=".NET Icon" class="a_icon"/>
+                                                data-track-section-title="implementation examples"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
+                                                data-track-title="dotnet sessions implementation"
+                                                data-track-text="Performing an online payment using sessions with Dotnet"
+                                                title="DotNet sessions implementation">
+                                                <img src="icons/languages/dot-net-original.svg" alt=".NET Icon"
+                                                    class="a_icon" />
                                                 <div class="icon-text">.NET</div>
                                             </a>
                                         </div>
-                                        
+
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-node-online-payments/tree/main/checkout-example"
-                                                data-track-section-title="implementation examples" 
-                                                data-track-component-name="card_item" 
-                                                data-track-action="clicked" data-track-type="card_item"
-                                                data-track-title="NodeJS sessions implementation" 
-                                                data-track-text="Performing an online payment using sessions with NodeJS"   
-                                                title="NodeJS sessions implementation"                                           
-                                                >
-                                                <img src="icons/languages/nodejs-original-wordmark.svg" alt="NodeJS Icon" class="a_icon"/>
+                                                data-track-section-title="implementation examples"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
+                                                data-track-title="NodeJS sessions implementation"
+                                                data-track-text="Performing an online payment using sessions with NodeJS"
+                                                title="NodeJS sessions implementation">
+                                                <img src="icons/languages/nodejs-original-wordmark.svg"
+                                                    alt="NodeJS Icon" class="a_icon" />
                                                 <div class="icon-text">Node.js</div>
                                             </a>
                                         </div>
@@ -155,29 +174,29 @@
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-vue-online-payments"
-                                                data-track-section-title="implementation examples" 
-                                                data-track-component-name="card_item" 
-                                                data-track-action="clicked" data-track-type="card_item"
-                                                data-track-title="VueJS sessions implementation" 
-                                                data-track-text="Performing an online payment using sessions with VueJS"  
-                                                title="VueJS sessions implementation"                                            
-                                                >
-                                                <img src="icons/languages/vuejs-original.svg" alt="VueJS Icon" class="a_icon"/>
+                                                data-track-section-title="implementation examples"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
+                                                data-track-title="VueJS sessions implementation"
+                                                data-track-text="Performing an online payment using sessions with VueJS"
+                                                title="VueJS sessions implementation">
+                                                <img src="icons/languages/vuejs-original.svg" alt="VueJS Icon"
+                                                    class="a_icon" />
                                                 <div class="icon-text">Vue.js</div>
-                                            </a>  
+                                            </a>
                                         </div>
 
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-react-online-payments"
-                                                data-track-section-title="implementation examples" 
-                                                data-track-component-name="card_item" 
-                                                data-track-action="clicked" data-track-type="card_item"
-                                                data-track-title="ReactJS sessions implementation" 
-                                                data-track-text="Performing an online payment using sessions with ReactJS"    
-                                                title="ReactJS sessions implementation"                                            
-                                                >
-                                                <img src="icons/languages/react-original.svg" alt="React Icon" class="a_icon"/>
+                                                data-track-section-title="implementation examples"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
+                                                data-track-title="ReactJS sessions implementation"
+                                                data-track-text="Performing an online payment using sessions with ReactJS"
+                                                title="ReactJS sessions implementation">
+                                                <img src="icons/languages/react-original.svg" alt="React Icon"
+                                                    class="a_icon" />
                                                 <div class="icon-text">React.js</div>
                                             </a>
                                         </div>
@@ -185,44 +204,44 @@
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-angular-online-payments"
-                                                data-track-section-title="implementation examples" 
-                                                data-track-component-name="card_item" 
-                                                data-track-action="clicked" data-track-type="card_item"
-                                                data-track-title="AngularJS sessions implementation" 
-                                                data-track-text="Performing an online payment using sessions with AngularJS"       
-                                                title="AngularJS sessions implementation"                                         
-                                                >
-                                                <img src="icons/languages/angularjs-original.svg" alt="AngularJS Icon" class="a_icon"/>
+                                                data-track-section-title="implementation examples"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
+                                                data-track-title="AngularJS sessions implementation"
+                                                data-track-text="Performing an online payment using sessions with AngularJS"
+                                                title="AngularJS sessions implementation">
+                                                <img src="icons/languages/angularjs-original.svg" alt="AngularJS Icon"
+                                                    class="a_icon" />
                                                 <div class="icon-text">Angular</div>
                                             </a>
                                         </div>
-                                        
+
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-android-online-payments"
-                                                data-track-section-title="implementation examples" 
-                                                data-track-component-name="card_item" 
-                                                data-track-action="clicked" data-track-type="card_item"
-                                                data-track-title="Android sessions implementation" 
-                                                data-track-text="Performing an online payment using sessions with Android"         
-                                                title="Android sessions implementation"                                       
-                                                >
-                                                <img src="icons/languages/android-original.svg" alt="Android Icon" class="a_icon"/>
+                                                data-track-section-title="implementation examples"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
+                                                data-track-title="Android sessions implementation"
+                                                data-track-text="Performing an online payment using sessions with Android"
+                                                title="Android sessions implementation">
+                                                <img src="icons/languages/android-original.svg" alt="Android Icon"
+                                                    class="a_icon" />
                                                 <div class="icon-text">Android</div>
-                                            </a>     
+                                            </a>
                                         </div>
 
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-rails-online-payments"
-                                                data-track-section-title="implementation examples" 
-                                                data-track-component-name="card_item" 
-                                                data-track-action="clicked" data-track-type="card_item"
-                                                data-track-title="Rails sessions implementation" 
-                                                data-track-text="Performing an online payment using sessions with Rails"    
-                                                title="Rails sessions implementation"                                            
-                                                >
-                                                <img src="icons/languages/rails-plain.svg" alt="Ruby on Rails Icon" class="a_icon"/>
+                                                data-track-section-title="implementation examples"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
+                                                data-track-title="Rails sessions implementation"
+                                                data-track-text="Performing an online payment using sessions with Rails"
+                                                title="Rails sessions implementation">
+                                                <img src="icons/languages/rails-plain.svg" alt="Ruby on Rails Icon"
+                                                    class="a_icon" />
                                                 <div class="icon-text">Ruby</div>
                                             </a>
                                         </div>
@@ -231,29 +250,29 @@
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-python-online-payments"
-                                                data-track-section-title="implementation examples" 
-                                                data-track-component-name="card_item" 
-                                                data-track-action="clicked" data-track-type="card_item"
-                                                data-track-title="Python sessions implementation" 
-                                                data-track-text="Performing an online payment using sessions with Python"  
-                                                title="Python sessions implementation"                                              
-                                                >
-                                                <img src="icons/languages/python-original.svg" alt="Python Icon" class="a_icon"/>
+                                                data-track-section-title="implementation examples"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
+                                                data-track-title="Python sessions implementation"
+                                                data-track-text="Performing an online payment using sessions with Python"
+                                                title="Python sessions implementation">
+                                                <img src="icons/languages/python-original.svg" alt="Python Icon"
+                                                    class="a_icon" />
                                                 <div class="icon-text">Python</div>
-                                            </a>  
+                                            </a>
                                         </div>
 
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-golang-online-payments"
-                                                data-track-section-title="implementation examples" 
-                                                data-track-component-name="card_item" 
-                                                data-track-action="clicked" data-track-type="card_item"
-                                                data-track-title="Golang sessions implementation" 
-                                                data-track-text="Performing an online payment using sessions with Golang" 
-                                                title="Golang sessions implementation"                                               
-                                                >
-                                                <img src="icons/languages/go-original-wordmark.svg" alt="Golang Icon" class="a_icon"/>
+                                                data-track-section-title="implementation examples"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
+                                                data-track-title="Golang sessions implementation"
+                                                data-track-text="Performing an online payment using sessions with Golang"
+                                                title="Golang sessions implementation">
+                                                <img src="icons/languages/go-original-wordmark.svg" alt="Golang Icon"
+                                                    class="a_icon" />
                                                 <div class="icon-text">Go</div>
                                             </a>
                                         </div>
@@ -262,34 +281,34 @@
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-php-online-payments"
-                                                data-track-section-title="implementation examples" 
-                                                data-track-component-name="card_item" 
-                                                data-track-action="clicked" data-track-type="card_item"
-                                                data-track-title="Laravel sessions implementation" 
-                                                data-track-text="Performing an online payment using sessions with Laravel"  
-                                                title="Laravel sessions implementation"                                             
-                                                >
-                                                <img src="icons/languages/laravel-original-wordmark.svg" alt="Laravel Icon" class="a_icon"/>
+                                                data-track-section-title="implementation examples"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
+                                                data-track-title="Laravel sessions implementation"
+                                                data-track-text="Performing an online payment using sessions with Laravel"
+                                                title="Laravel sessions implementation">
+                                                <img src="icons/languages/laravel-original-wordmark.svg"
+                                                    alt="Laravel Icon" class="a_icon" />
                                                 <div class="icon-text">PHP</div>
-                                            </a>      
+                                            </a>
                                         </div>
 
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-kotlin-spring-online-payments"
-                                                data-track-section-title="implementation examples" 
-                                                data-track-component-name="card_item" 
-                                                data-track-action="clicked" data-track-type="card_item"
-                                                data-track-title="Kotlin sessions implementation" 
-                                                data-track-text="Performing an online payment using sessions with Kotlin"  
-                                                title="Kotlin sessions implementation"                                              
-                                                >
-                                                <img src="icons/languages/kotlin-original.svg" alt="Kotlin Icon" class="a_icon"/>
+                                                data-track-section-title="implementation examples"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
+                                                data-track-title="Kotlin sessions implementation"
+                                                data-track-text="Performing an online payment using sessions with Kotlin"
+                                                title="Kotlin sessions implementation">
+                                                <img src="icons/languages/kotlin-original.svg" alt="Kotlin Icon"
+                                                    class="a_icon" />
                                                 <div class="icon-text">Kotlin</div>
                                             </a>
                                         </div>
-                    
-                                    </div>                                                                                                                                                                                                                                                                                                      
+
+                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -297,7 +316,7 @@
 
                     <!-- Advanced Online Payments -->
                     <div class="card_item card_item_box_shadow_small">
-                        <div class="card_item_top" >
+                        <div class="card_item_top">
                             <div class="content">
                                 <img src="icons/github.svg" alt="" class="icon">
                                 <h5 class="title">Advanced Online Payments</h5>
@@ -308,14 +327,14 @@
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-java-spring-online-payments/tree/main/checkout-example-advanced"
-                                                data-track-section-title="implementation examples" 
-                                                data-track-component-name="card_item" 
-                                                data-track-action="clicked" data-track-type="card_item"
-                                                data-track-title="Java Spring complex implementation" 
-                                                data-track-text="Performing a complex online payment with Java Spring"  
-                                                title="Java Spring complex implementation"                                              
-                                                >
-                                                <img src="icons/languages/java-original.svg" alt="Java Icon" class="a_icon"/>
+                                                data-track-section-title="implementation examples"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
+                                                data-track-title="Java Spring complex implementation"
+                                                data-track-text="Performing a complex online payment with Java Spring"
+                                                title="Java Spring complex implementation">
+                                                <img src="icons/languages/java-original.svg" alt="Java Icon"
+                                                    class="a_icon" />
                                                 <div class="icon-text">Java</div>
                                             </a>
                                         </div>
@@ -323,33 +342,33 @@
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-dotnet-online-payments/tree/main/checkout-example-advanced"
-                                                data-track-section-title="implementation examples" 
-                                                data-track-component-name="card_item" 
-                                                data-track-action="clicked" data-track-type="card_item"
-                                                data-track-title="DotNet complex implementation" 
-                                                data-track-text="Performing a complex online payment with DotNet"             
-                                                title="DotNet complex implementation"                                   
-                                                >
-                                                <img src="icons/languages/dot-net-original.svg" alt=".NET Icon" class="a_icon"/>
+                                                data-track-section-title="implementation examples"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
+                                                data-track-title="DotNet complex implementation"
+                                                data-track-text="Performing a complex online payment with DotNet"
+                                                title="DotNet complex implementation">
+                                                <img src="icons/languages/dot-net-original.svg" alt=".NET Icon"
+                                                    class="a_icon" />
                                                 <div class="icon-text">.NET</div>
                                             </a>
                                         </div>
-                                        
+
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-node-online-payments/tree/main/checkout-example-advanced"
-                                                data-track-section-title="implementation examples" 
-                                                data-track-component-name="card_item" 
-                                                data-track-action="clicked" data-track-type="card_item"
-                                                data-track-title="NodeJS complex implementation" 
-                                                data-track-text="Performing a complex online payment with NodeJS"   
-                                                title="NodeJS complex implementation"                                             
-                                                >
-                                                <img src="icons/languages/nodejs-original-wordmark.svg" alt="NodeJS Icon" class="a_icon"/>
+                                                data-track-section-title="implementation examples"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
+                                                data-track-title="NodeJS complex implementation"
+                                                data-track-text="Performing a complex online payment with NodeJS"
+                                                title="NodeJS complex implementation">
+                                                <img src="icons/languages/nodejs-original-wordmark.svg"
+                                                    alt="NodeJS Icon" class="a_icon" />
                                                 <div class="icon-text">Node.js</div>
                                             </a>
                                         </div>
-                                    </div>                                                                                                                                                                                    
+                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -357,7 +376,7 @@
 
                     <!--Plugins -->
                     <div class="card_item card_item_box_shadow_small">
-                        <div class="card_item_top" >
+                        <div class="card_item_top">
                             <div class="content">
                                 <img src="icons/github.svg" alt="" class="icon">
                                 <h5 class="title">Plugins</h5>
@@ -367,49 +386,49 @@
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-magento-plugin-demo"
-                                                data-track-section-title="implementation examples" 
-                                                data-track-component-name="card_item" 
-                                                data-track-action="clicked" data-track-type="card_item"
-                                                data-track-title="Magento payments plugin implementation" 
-                                                data-track-text="Perform online, in-app, and in-person payments using Adyen plugin for Magento"  
-                                                title="Magento payments plugin implementation"                                              
-                                                >
-                                                <img src="icons/languages/magento-original.svg" alt="Magento Icon" class="a_icon"/>
+                                                data-track-section-title="implementation examples"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
+                                                data-track-title="Magento payments plugin implementation"
+                                                data-track-text="Perform online, in-app, and in-person payments using Adyen plugin for Magento"
+                                                title="Magento payments plugin implementation">
+                                                <img src="icons/languages/magento-original.svg" alt="Magento Icon"
+                                                    class="a_icon" />
                                                 <div class="icon-text">Magento</div>
                                             </a>
                                         </div>
-                                            
+
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-shopware-plugin-demo"
-                                                data-track-section-title="implementation examples" 
-                                                data-track-component-name="card_item" 
-                                                data-track-action="clicked" data-track-type="card_item"
-                                                data-track-title="Shopware payments plugin implementation" 
-                                                data-track-text="Perform online payments using Adyen plugin for Shopware"  
-                                                title="Shopware payments plugin implementation"                                              
-                                                >
-                                                <img src="icons/languages/shopware-original.svg" alt="Shopware Icon" class="a_icon"/>
+                                                data-track-section-title="implementation examples"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
+                                                data-track-title="Shopware payments plugin implementation"
+                                                data-track-text="Perform online payments using Adyen plugin for Shopware"
+                                                title="Shopware payments plugin implementation">
+                                                <img src="icons/languages/shopware-original.svg" alt="Shopware Icon"
+                                                    class="a_icon" />
                                                 <div class="icon-text">Shopware</div>
                                             </a>
                                         </div>
-                                            
+
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-salesforce-pwa-headless-demo"
-                                                data-track-section-title="implementation examples" 
-                                                data-track-component-name="card_item" 
-                                                data-track-action="clicked" data-track-type="card_item"
-                                                data-track-title="Salesforce composable storefront implementation" 
-                                                data-track-text="Perform online payments using Adyen plugin for Salesforce composable storefront - PWA"  
-                                                title="Salesforce composable storefront implementation"                                              
-                                                >
-                                                <img src="icons/languages/salesforce-plain.svg" alt="Saleforce Icon" class="a_icon"/>
+                                                data-track-section-title="implementation examples"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
+                                                data-track-title="Salesforce composable storefront implementation"
+                                                data-track-text="Perform online payments using Adyen plugin for Salesforce composable storefront - PWA"
+                                                title="Salesforce composable storefront implementation">
+                                                <img src="icons/languages/salesforce-plain.svg" alt="Saleforce Icon"
+                                                    class="a_icon" />
                                                 <div class="icon-text">Salesforce</div>
                                             </a>
                                         </div>
-                                        
-                                    </div>                                                                                                                                                                                    
+
+                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -417,7 +436,7 @@
 
                     <!-- Recurring Payments -->
                     <div class="card_item card_item_box_shadow_small">
-                        <div class="card_item_top" >
+                        <div class="card_item_top">
                             <div class="content">
                                 <img src="icons/github.svg" alt="" class="icon">
                                 <h5 class="title">Recurring Payments</h5>
@@ -427,47 +446,47 @@
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-java-spring-online-payments/tree/main/subscription-example"
-                                                data-track-section-title="implementation examples" 
-                                                data-track-component-name="card_item" 
-                                                data-track-action="clicked" data-track-type="card_item"
-                                                data-track-title="Java Spring subscriptions implementation" 
-                                                data-track-text="Managing subscriptions with Java Spring"   
-                                                title="Java Spring subscriptions implementation"                                             
-                                                >
-                                                <img src="icons/languages/java-original.svg" alt="Java Icon" class="a_icon"/>
+                                                data-track-section-title="implementation examples"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
+                                                data-track-title="Java Spring subscriptions implementation"
+                                                data-track-text="Managing subscriptions with Java Spring"
+                                                title="Java Spring subscriptions implementation">
+                                                <img src="icons/languages/java-original.svg" alt="Java Icon"
+                                                    class="a_icon" />
                                                 <div class="icon-text">Java</div>
                                             </a>
                                         </div>
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-dotnet-online-payments/tree/main/subscription-example"
-                                                data-track-section-title="implementation examples" 
-                                                data-track-component-name="card_item" 
-                                                data-track-action="clicked" data-track-type="card_item"
-                                                data-track-title="DotNet subscriptions implementation" 
-                                                data-track-text="Managing subscriptions with DotNet"              
-                                                title="DotNet subscriptions implementation"                                 
-                                                >
-                                                <img src="icons/languages/dot-net-original.svg" alt=".NET Icon" class="a_icon"/>
+                                                data-track-section-title="implementation examples"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
+                                                data-track-title="DotNet subscriptions implementation"
+                                                data-track-text="Managing subscriptions with DotNet"
+                                                title="DotNet subscriptions implementation">
+                                                <img src="icons/languages/dot-net-original.svg" alt=".NET Icon"
+                                                    class="a_icon" />
                                                 <div class="icon-text">.NET</div>
                                             </a>
                                         </div>
-                                        
+
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-node-online-payments/tree/main/subscription-example"
-                                                data-track-section-title="implementation examples" 
-                                                data-track-component-name="card_item" 
-                                                data-track-action="clicked" data-track-type="card_item"
-                                                data-track-title="NodeJS subscriptions implementation" 
-                                                data-track-text="Managing subscriptions with NodeJS"                   
-                                                title="NodeJS subscriptions implementation"                            
-                                                >
-                                                <img src="icons/languages/nodejs-original-wordmark.svg" alt="NodeJS Icon" class="a_icon"/>
+                                                data-track-section-title="implementation examples"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
+                                                data-track-title="NodeJS subscriptions implementation"
+                                                data-track-text="Managing subscriptions with NodeJS"
+                                                title="NodeJS subscriptions implementation">
+                                                <img src="icons/languages/nodejs-original-wordmark.svg"
+                                                    alt="NodeJS Icon" class="a_icon" />
                                                 <div class="icon-text">Node.js</div>
                                             </a>
                                         </div>
-                                    </div>                                                                                                                                                                                 
+                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -475,59 +494,58 @@
 
                     <!-- Gift Cards -->
                     <div class="card_item card_item_box_shadow_small">
-                        <div class="card_item_top" >
+                        <div class="card_item_top">
                             <div class="content">
                                 <img src="icons/github.svg" alt="" class="icon">
                                 <h5 class="title">Gift Cards</h5>
                                 <div class="descrp">
                                     <p>Perform partial payments using gift cards</p>
                                     <div class="links_list">
-                                        
+
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-java-spring-online-payments/tree/main/giftcard-example"
-                                                data-track-section-title="implementation examples" 
-                                                data-track-component-name="card_item" 
-                                                data-track-action="clicked" data-track-type="card_item"
-                                                data-track-title="Java Spring Gift Cards implementation" 
-                                                data-track-text="Managing Gift Cards with Java Spring"                 
-                                                title="Java Spring Gift Cards implementation"                              
-                                                >
-                                                <img src="icons/languages/java-original.svg" alt="Java Icon" class="a_icon"/>
+                                                data-track-section-title="implementation examples"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
+                                                data-track-title="Java Spring Gift Cards implementation"
+                                                data-track-text="Managing Gift Cards with Java Spring"
+                                                title="Java Spring Gift Cards implementation">
+                                                <img src="icons/languages/java-original.svg" alt="Java Icon"
+                                                    class="a_icon" />
                                                 <div class="icon-text">Java</div>
                                             </a>
                                         </div>
-                                    
+
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-dotnet-online-payments/tree/main/giftcard-example"
-                                                data-track-section-title="implementation examples" 
-                                                data-track-component-name="card_item" 
-                                                data-track-action="clicked" data-track-type="card_item"
-                                                data-track-title="DotNet Gift Cards implementation" 
-                                                data-track-text="Managing gift cards with DotNet"              
-                                                title="DotNet Gift Cards implementation"                                 
-                                                >
-                                                <img src="icons/languages/dot-net-original.svg" alt=".NET Icon" class="a_icon"/>
+                                                data-track-section-title="implementation examples"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
+                                                data-track-title="DotNet Gift Cards implementation"
+                                                data-track-text="Managing gift cards with DotNet"
+                                                title="DotNet Gift Cards implementation">
+                                                <img src="icons/languages/dot-net-original.svg" alt=".NET Icon"
+                                                    class="a_icon" />
                                                 <div class="icon-text">.NET</div>
                                             </a>
                                         </div>
-                                    
+
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-node-online-payments/tree/main/giftcard-example"
-                                                data-track-section-title="implementation examples" 
-                                                data-track-component-name="card_item" 
-                                                data-track-action="clicked" data-track-type="card_item"
-                                                data-track-title="NodeJS implementation" 
-                                                data-track-text="Managing Gift Cards with NodeJS"      
-                                                title="NodeJS Gift Cards implementation"                                         
-                                                >
-                                                <img src="icons/languages/nodejs-original-wordmark.svg" alt="NodeJS Icon" class="a_icon"/>
+                                                data-track-section-title="implementation examples"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item" data-track-title="NodeJS implementation"
+                                                data-track-text="Managing Gift Cards with NodeJS"
+                                                title="NodeJS Gift Cards implementation">
+                                                <img src="icons/languages/nodejs-original-wordmark.svg"
+                                                    alt="NodeJS Icon" class="a_icon" />
                                                 <div class="icon-text">Node.js</div>
                                             </a>
-                                        </div>       
-                                    </div>                                                                                                                                                                               
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -535,115 +553,116 @@
 
                     <!-- Pay by Link -->
                     <div class="card_item card_item_box_shadow_small">
-                        <div class="card_item_top" >
+                        <div class="card_item_top">
                             <div class="content">
                                 <img src="icons/github.svg" alt="" class="icon">
                                 <h5 class="title">Pay by Link</h5>
                                 <div class="descrp">
                                     <p>Create and manage payment links</p>
                                     <div class="links_list">
-                                        
+
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-java-spring-online-payments/tree/main/paybylink-example"
-                                                data-track-section-title="implementation examples" 
-                                                data-track-component-name="card_item" 
-                                                data-track-action="clicked" data-track-type="card_item"
-                                                data-track-title="Java Spring Payment Links implementation" 
-                                                data-track-text="Managing Payment Links with Java Spring"             
-                                                title="Java Spring Payment Links implementation"                                  
-                                                >
-                                                <img src="icons/languages/java-original.svg" alt="Java Icon" class="a_icon"/>
+                                                data-track-section-title="implementation examples"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
+                                                data-track-title="Java Spring Payment Links implementation"
+                                                data-track-text="Managing Payment Links with Java Spring"
+                                                title="Java Spring Payment Links implementation">
+                                                <img src="icons/languages/java-original.svg" alt="Java Icon"
+                                                    class="a_icon" />
                                                 <div class="icon-text">Java</div>
                                             </a>
                                         </div>
-                                        
+
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-dotnet-online-payments/tree/main/paybylink-example"
-                                                data-track-section-title="implementation examples" 
-                                                data-track-component-name="card_item" 
-                                                data-track-action="clicked" data-track-type="card_item"
-                                                data-track-title="DotNet Payment Links implementation" 
-                                                data-track-text="Managing Payment Links with DotNet"               
-                                                title="DotNet Payment Links implementation"                                
-                                                >
-                                                <img src="icons/languages/dot-net-original.svg" alt=".NET Icon" class="a_icon"/>
+                                                data-track-section-title="implementation examples"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
+                                                data-track-title="DotNet Payment Links implementation"
+                                                data-track-text="Managing Payment Links with DotNet"
+                                                title="DotNet Payment Links implementation">
+                                                <img src="icons/languages/dot-net-original.svg" alt=".NET Icon"
+                                                    class="a_icon" />
                                                 <div class="icon-text">.NET</div>
                                             </a>
                                         </div>
-                                        
+
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-node-online-payments/tree/main/paybylink-example"
-                                                data-track-section-title="implementation examples" 
-                                                data-track-component-name="card_item" 
-                                                data-track-action="clicked" data-track-type="card_item"
-                                                data-track-title="NodeJS Payment Links implementation" 
-                                                data-track-text="Managing Payment Links with NodeJS"                 
-                                                title="NodeJS Payment Links implementation"                              
-                                                >
-                                                <img src="icons/languages/nodejs-original-wordmark.svg" alt="NodeJS Icon" class="a_icon"/>
+                                                data-track-section-title="implementation examples"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
+                                                data-track-title="NodeJS Payment Links implementation"
+                                                data-track-text="Managing Payment Links with NodeJS"
+                                                title="NodeJS Payment Links implementation">
+                                                <img src="icons/languages/nodejs-original-wordmark.svg"
+                                                    alt="NodeJS Icon" class="a_icon" />
                                                 <div class="icon-text">Node.js</div>
                                             </a>
-                                        </div> 
-                                    </div>                                                                                                                                                                                   
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
                         </div>
                     </div>
-                    
+
                     <!-- Authorisation Adjustment -->
                     <div class="card_item card_item_box_shadow_small">
-                        <div class="card_item_top" >
+                        <div class="card_item_top">
                             <div class="content">
                                 <img src="icons/github.svg" alt="" class="icon">
                                 <h5 class="title">Authorisation Adjustment</h5>
                                 <div class="descrp">
-                                    <p>Pre-authorise payments, adjust the amount and capture, cancel or refund the payment</p>
+                                    <p>Pre-authorise payments, adjust the amount and capture, cancel or refund the
+                                        payment</p>
                                     <div class="links_list">
-                                        
+
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-java-spring-online-payments/tree/main/authorisation-adjustment-example"
                                                 data-track-section-title="implementation examples"
-                                                data-track-component-name="card_item"
-                                                data-track-action="clicked" data-track-type="card_item"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
                                                 data-track-title="Java Authorisation Adjustment implementation"
                                                 data-track-text="Managing Authorisation Adjustment with Java"
-                                                title="Java Authorisation Adjustment implementation"
-                                                >
-                                                <img src="icons/languages/java-original.svg" alt="Java Icon" class="a_icon"/>
+                                                title="Java Authorisation Adjustment implementation">
+                                                <img src="icons/languages/java-original.svg" alt="Java Icon"
+                                                    class="a_icon" />
                                                 <div class="icon-text">Java</div>
                                             </a>
                                         </div>
-                                        
+
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-dotnet-online-payments/tree/main/authorisation-adjustment-example"
                                                 data-track-section-title="implementation examples"
-                                                data-track-component-name="card_item"
-                                                data-track-action="clicked" data-track-type="card_item"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
                                                 data-track-title="DotNet Authorisation Adjustment implementation"
                                                 data-track-text="Managing Authorisation Adjustment with DotNet"
-                                                title="DotNet Authorisation Adjustment implementation"
-                                                >
-                                                <img src="icons/languages/dot-net-original.svg" alt=".NET Icon" class="a_icon"/>
+                                                title="DotNet Authorisation Adjustment implementation">
+                                                <img src="icons/languages/dot-net-original.svg" alt=".NET Icon"
+                                                    class="a_icon" />
                                                 <div class="icon-text">.NET</div>
                                             </a>
                                         </div>
-                                        
+
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-node-online-payments/tree/main/authorisation-adjustment-example"
-                                                data-track-section-title="implementation examples" 
-                                                data-track-component-name="card_item" 
-                                                data-track-action="clicked" data-track-type="card_item"
-                                                data-track-title="NodeJS Authorisation Adjustment implementation" 
-                                                data-track-text="Managing Authorisation Adjustment with NodeJS"                 
-                                                title="NodeJS Authorisation Adjustment implementation"                              
-                                                >
-                                                <img src="icons/languages/nodejs-original-wordmark.svg" alt="NodeJS Icon" class="a_icon"/>
+                                                data-track-section-title="implementation examples"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
+                                                data-track-title="NodeJS Authorisation Adjustment implementation"
+                                                data-track-text="Managing Authorisation Adjustment with NodeJS"
+                                                title="NodeJS Authorisation Adjustment implementation">
+                                                <img src="icons/languages/nodejs-original-wordmark.svg"
+                                                    alt="NodeJS Icon" class="a_icon" />
                                                 <div class="icon-text">Node.js</div>
                                             </a>
                                         </div>
@@ -655,56 +674,57 @@
 
                     <!-- Giving -->
                     <div class="card_item card_item_box_shadow_small">
-                        <div class="card_item_top" >
+                        <div class="card_item_top">
                             <div class="content">
                                 <img src="icons/github.svg" alt="" class="icon">
                                 <h5 class="title">Adyen Giving (Donations)</h5>
                                 <div class="descrp">
-                                    <p>Give your shoppers the option to donate to a charity as part of your payment flow.</p>
+                                    <p>Give your shoppers the option to donate to a charity as part of your payment
+                                        flow.</p>
                                     <div class="links_list">
-                                        
+
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-java-spring-online-payments/tree/main/giving-example"
-                                                data-track-section-title="implementation examples" 
-                                                data-track-component-name="card_item" 
-                                                data-track-action="clicked" data-track-type="card_item"
-                                                data-track-title="Java Spring Adyen Giving implementation" 
-                                                data-track-text="Give your shoppers the option to donate to a charity with Java Spring"             
-                                                title="Java Spring Adyen Giving implementation"                                  
-                                                >
-                                                <img src="icons/languages/java-original.svg" alt="Java Icon" class="a_icon"/>
+                                                data-track-section-title="implementation examples"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
+                                                data-track-title="Java Spring Adyen Giving implementation"
+                                                data-track-text="Give your shoppers the option to donate to a charity with Java Spring"
+                                                title="Java Spring Adyen Giving implementation">
+                                                <img src="icons/languages/java-original.svg" alt="Java Icon"
+                                                    class="a_icon" />
                                                 <div class="icon-text">Java</div>
                                             </a>
                                         </div>
-                                        
+
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-dotnet-online-payments/tree/main/giving-example"
                                                 data-track-section-title="implementation examples"
-                                                data-track-component-name="card_item"
-                                                data-track-action="clicked" data-track-type="card_item"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
                                                 data-track-title="DotNet Adyen Giving implementation"
                                                 data-track-text="Give your shoppers the option to donate to a charity with DotNet"
-                                                title="DotNet Adyen Giving implementation"
-                                                >
-                                                <img src="icons/languages/dot-net-original.svg" alt=".NET Icon" class="a_icon"/>
+                                                title="DotNet Adyen Giving implementation">
+                                                <img src="icons/languages/dot-net-original.svg" alt=".NET Icon"
+                                                    class="a_icon" />
                                                 <div class="icon-text">.NET</div>
                                             </a>
-    
+
                                         </div>
-                                    
+
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-node-online-payments/tree/main/giving-example"
                                                 data-track-section-title="implementation examples"
-                                                data-track-component-name="card_item"
-                                                data-track-action="clicked" data-track-type="card_item"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
                                                 data-track-title="NodeJS Adyen Giving implementation"
                                                 data-track-text="Give your shoppers the option to donate to a charity with NodeJS"
-                                                title="NodeJS Adyen Giving implementation"
-                                                >
-                                                <img src="icons/languages/nodejs-original-wordmark.svg" alt="NodeJS Icon" class="a_icon"/>
+                                                title="NodeJS Adyen Giving implementation">
+                                                <img src="icons/languages/nodejs-original-wordmark.svg"
+                                                    alt="NodeJS Icon" class="a_icon" />
                                                 <div class="icon-text">Node.js</div>
                                             </a>
                                         </div>
@@ -716,7 +736,7 @@
 
                     <!-- 3DS2 Authentication-->
                     <div class="card_item card_item_box_shadow_small">
-                        <div class="card_item_top" >
+                        <div class="card_item_top">
                             <div class="content">
                                 <img src="icons/github.svg" alt="" class="icon">
                                 <h5 class="title">3DS2 Authentication</h5>
@@ -727,13 +747,13 @@
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-node-online-payments/tree/main/3ds2-example"
                                                 data-track-section-title="implementation examples"
-                                                data-track-component-name="card_item"
-                                                data-track-action="clicked" data-track-type="card_item"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
                                                 data-track-title="NodeJS 3DS2 Authentication implementation"
                                                 data-track-text="Performing a 3DS2 Authentication with NodeJS"
-                                                title="NodeJS 3DS Authentication implementation"
-                                                >
-                                                <img src="icons/languages/nodejs-original-wordmark.svg" alt="NodeJS Icon" class="a_icon"/>
+                                                title="NodeJS 3DS Authentication implementation">
+                                                <img src="icons/languages/nodejs-original-wordmark.svg"
+                                                    alt="NodeJS Icon" class="a_icon" />
                                                 <div class="icon-text">Node.js</div>
                                             </a>
                                         </div>
@@ -742,57 +762,58 @@
                             </div>
                         </div>
                     </div>
-                    
+
                     <!-- In-person Payments -->
                     <div class="card_item card_item_box_shadow_small">
-                        <div class="card_item_top" >
+                        <div class="card_item_top">
                             <div class="content">
                                 <img src="icons/github.svg" alt="" class="icon">
                                 <h5 class="title">In-person Payments</h5>
                                 <div class="descrp">
-                                    <p>Make payment, reversal, abort and transaction-status requests to a POS terminal.</p>
+                                    <p>Make payment, reversal, abort and transaction-status requests to a POS terminal.
+                                    </p>
                                     <div class="links_list">
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-java-spring-online-payments/tree/main/in-person-payments-example"
                                                 data-track-section-title="implementation examples"
-                                                data-track-component-name="card_item"
-                                                data-track-action="clicked" data-track-type="card_item"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
                                                 data-track-title="Java In-person Payments implementation"
                                                 data-track-text="Managing In-person Payments with Java"
-                                                title="Java In-person Payments implementation"
-                                                >
-                                                <img src="icons/languages/java-original.svg" alt="Java Icon" class="a_icon"/>
+                                                title="Java In-person Payments implementation">
+                                                <img src="icons/languages/java-original.svg" alt="Java Icon"
+                                                    class="a_icon" />
                                                 <div class="icon-text">Java</div>
                                             </a>
                                         </div>
-                                        
+
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-dotnet-online-payments/tree/main/in-person-payments-example"
                                                 data-track-section-title="implementation examples"
-                                                data-track-component-name="card_item"
-                                                data-track-action="clicked" data-track-type="card_item"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
                                                 data-track-title="DotNet In-person Payments implementation"
                                                 data-track-text="Managing In-person Payments with DotNet"
-                                                title="DotNet In-person Payments implementation"
-                                                >
-                                                <img src="icons/languages/dot-net-original.svg" alt=".NET Icon" class="a_icon"/>
+                                                title="DotNet In-person Payments implementation">
+                                                <img src="icons/languages/dot-net-original.svg" alt=".NET Icon"
+                                                    class="a_icon" />
                                                 <div class="icon-text">.NET</div>
                                             </a>
                                         </div>
-                                        
+
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-node-online-payments/tree/main/in-person-payments-example"
                                                 data-track-section-title="implementation examples"
-                                                data-track-component-name="card_item"
-                                                data-track-action="clicked" data-track-type="card_item"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
                                                 data-track-title="NodeJS In-person Payments implementation"
                                                 data-track-text="Managing In-person Payments with NodeJS"
-                                                title="NodeJS In-person Payments implementation"
-                                                >
-                                                <img src="icons/languages/nodejs-original-wordmark.svg" alt="NodeJS Icon" class="a_icon"/>
+                                                title="NodeJS In-person Payments implementation">
+                                                <img src="icons/languages/nodejs-original-wordmark.svg"
+                                                    alt="NodeJS Icon" class="a_icon" />
                                                 <div class="icon-text">Node.js</div>
                                             </a>
                                         </div>
@@ -801,28 +822,28 @@
                             </div>
                         </div>
                     </div>
-                    
+
                     <!-- In-person Payments Loyalty -->
                     <div class="card_item card_item_box_shadow_small">
-                        <div class="card_item_top" >
+                        <div class="card_item_top">
                             <div class="content">
                                 <img src="icons/github.svg" alt="" class="icon">
                                 <h5 class="title">In-person Payments Loyalty</h5>
                                 <div class="descrp">
                                     <p>Make card acquisition requests to a POS terminal.</p>
                                     <div class="links_list">
-                                        
+
                                         <div class="icon-text-container">
                                             <a target="_blank" rel="noopener"
                                                 href="https://github.com/adyen-examples/adyen-dotnet-online-payments/tree/main/in-person-payments-loyalty-example"
                                                 data-track-section-title="implementation examples"
-                                                data-track-component-name="card_item"
-                                                data-track-action="clicked" data-track-type="card_item"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
                                                 data-track-title="DotNet In-person Payments Loyalty implementation"
                                                 data-track-text="Managing In-person Payments Loyalty with DotNet"
-                                                title="DotNet In-person Payments Loyalty implementation"
-                                                >
-                                                <img src="icons/languages/dot-net-original.svg" alt=".NET Icon" class="a_icon"/>
+                                                title="DotNet In-person Payments Loyalty implementation">
+                                                <img src="icons/languages/dot-net-original.svg" alt=".NET Icon"
+                                                    class="a_icon" />
                                                 <div class="icon-text">.NET</div>
                                             </a>
                                         </div>
@@ -834,7 +855,7 @@
 
                     <!-- Adyen for Platforms -->
                     <div class="card_item card_item_box_shadow_small">
-                        <div class="card_item_top" >
+                        <div class="card_item_top">
                             <div class="content">
                                 <img src="icons/github.svg" alt="" class="icon">
                                 <h5 class="title">Adyen for Platforms</h5>
@@ -842,17 +863,16 @@
                                     <p>Onboard users of your platform or marketplace, process payments and payouts.</p>
                                     <div class="links_list">
                                         <div class="icon-text-container">
-                                            <a target="_blank" rel="noopener"
-                                                class="a_icon devicon-java-plain colored"
+                                            <a target="_blank" rel="noopener" class="a_icon devicon-java-plain colored"
                                                 href="https://github.com/adyen-examples/adyen-afp-sample"
                                                 data-track-section-title="implementation examples"
-                                                data-track-component-name="card_item"
-                                                data-track-action="clicked" data-track-type="card_item"
+                                                data-track-component-name="card_item" data-track-action="clicked"
+                                                data-track-type="card_item"
                                                 data-track-title="Java Adyen for Platforms implementation"
                                                 data-track-text="Adyen for Platforms with Java"
-                                                title="Java Adyen for Platforms implementation"
-                                                    >
-                                                <img src="icons/languages/java-original.svg" alt="Java Icon" class="a_icon"/>
+                                                title="Java Adyen for Platforms implementation">
+                                                <img src="icons/languages/java-original.svg" alt="Java Icon"
+                                                    class="a_icon" />
                                                 <div class="icon-text">Java</div>
                                             </a>
                                         </div>
@@ -861,12 +881,12 @@
                             </div>
                         </div>
                     </div>
-                    
+
                 </div>
             </div>
-        </section>         
+        </section>
         <!-- Implementation examples end-->
-        
+
         <!-- Developer Tools start -->
         <section class="sect resources" data-track-section-title="Developer Tools">
             <div class="container">
@@ -875,8 +895,11 @@
                     <p>All the tools and locations to help you start integration fast.</p>
                 </div>
                 <div class="card">
-                    <a target="_blank" rel="noopener" href="https://docs.adyen.com/" class="card_item" data-track-component-name="card_item" data-track-section-title="developer tools" data-track-title="documentation" data-track-text="our exhaustive documentation" data-track-action="clicked" data-track-type="card_item">
-                        <div class="card_item_top" >
+                    <a target="_blank" rel="noopener" href="https://docs.adyen.com/" class="card_item"
+                        data-track-component-name="card_item" data-track-section-title="developer tools"
+                        data-track-title="documentation" data-track-text="our exhaustive documentation"
+                        data-track-action="clicked" data-track-type="card_item">
+                        <div class="card_item_top">
                             <div class="content">
                                 <img src="icons/library.svg" alt="" class="icon">
                                 <h4 class="title">Documentation</h4>
@@ -887,7 +910,10 @@
                         </div>
                     </a>
 
-                    <a target="_blank" rel="noopener" href="https://docs.adyen.com/api-explorer/" class="card_item" data-track-component-name="card_item" data-track-section-title="developer tools" data-track-title="api explorer" data-track-text="our official api reference" data-track-action="clicked" data-track-type="card_item">
+                    <a target="_blank" rel="noopener" href="https://docs.adyen.com/api-explorer/" class="card_item"
+                        data-track-component-name="card_item" data-track-section-title="developer tools"
+                        data-track-title="api explorer" data-track-text="our official api reference"
+                        data-track-action="clicked" data-track-type="card_item">
                         <div class="card_item_top">
                             <div class="content">
                                 <img src="icons/api-explorer.svg" alt="" class="icon">
@@ -899,7 +925,10 @@
                         </div>
                     </a>
 
-                    <a target="_blank" rel="noopener" href="https://github.com/adyen-examples/" class="card_item" data-track-component-name="card_item" data-track-section-title="developer tools" data-track-title="github samples" data-track-text="integration samples in multiple languages" data-track-action="clicked" data-track-type="card_item">
+                    <a target="_blank" rel="noopener" href="https://github.com/adyen-examples/" class="card_item"
+                        data-track-component-name="card_item" data-track-section-title="developer tools"
+                        data-track-title="github samples" data-track-text="integration samples in multiple languages"
+                        data-track-action="clicked" data-track-type="card_item">
                         <div class="card_item_top">
                             <div class="content">
                                 <img src="icons/github.svg" alt="" class="icon">
@@ -911,7 +940,11 @@
                         </div>
                     </a>
 
-                    <a target="_blank" rel="noopener" href="https://postman.com/adyendev/" class="card_item" data-track-component-name="card_item" data-track-section-title="developer tools" data-track-title="postman workspace" data-track-text="all of our apis available as postman collections" data-track-action="clicked" data-track-type="card_item">
+                    <a target="_blank" rel="noopener" href="https://postman.com/adyendev/" class="card_item"
+                        data-track-component-name="card_item" data-track-section-title="developer tools"
+                        data-track-title="postman workspace"
+                        data-track-text="all of our apis available as postman collections" data-track-action="clicked"
+                        data-track-type="card_item">
                         <div class="card_item_top">
                             <div class="content">
                                 <img src="icons/postman.svg" alt="" class="icon">
@@ -923,7 +956,12 @@
                         </div>
                     </a>
 
-                    <a target="_blank" rel="noopener" href="https://docs.adyen.com/development-resources/testing/test-card-numbers" class="card_item" data-track-component-name="card_item" data-track-section-title="developer tools" data-track-title="test cards" data-track-text="test your integration with our test card numbers and payment method details" data-track-action="clicked" data-track-type="card_item">
+                    <a target="_blank" rel="noopener"
+                        href="https://docs.adyen.com/development-resources/testing/test-card-numbers" class="card_item"
+                        data-track-component-name="card_item" data-track-section-title="developer tools"
+                        data-track-title="test cards"
+                        data-track-text="test your integration with our test card numbers and payment method details"
+                        data-track-action="clicked" data-track-type="card_item">
                         <div class="card_item_top">
                             <div class="content">
                                 <img src="icons/credit-card.svg" alt="" class="icon">
@@ -935,11 +973,14 @@
                         </div>
                     </a>
 
-                    <a target="_blank" rel="noopener" href="https://github.com/adyen" class="card_item" data-track-component-name="card_item" data-track-section-title="developer tools" data-track-title="adyen sdks" data-track-text="the source for all of our sdks and more" data-track-action="clicked" data-track-type="card_item">
+                    <a target="_blank" rel="noopener" href="https://github.com/adyen" class="card_item"
+                        data-track-component-name="card_item" data-track-section-title="developer tools"
+                        data-track-title="adyen sdks" data-track-text="the source for all of our sdks and more"
+                        data-track-action="clicked" data-track-type="card_item">
                         <div class="card_item_top">
                             <div class="content">
                                 <img src="icons/plugins.svg" alt="" class="icon">
-                                <h4 class="title">Adyen SDKs    </h4>
+                                <h4 class="title">Adyen SDKs </h4>
                                 <div class="descrp">
                                     <p>The source for all of our SDKs and more</p>
                                 </div>
@@ -950,8 +991,8 @@
             </div>
         </section>
         <!-- Developer Tools end -->
-        
-        <!-- Diving further start --> 
+
+        <!-- Diving further start -->
         <section class="sect resources">
             <div class="container">
                 <div class="sect_header">
@@ -960,7 +1001,11 @@
                 </div>
                 <div class="card">
 
-                    <a target="_blank" rel="noopener" href="https://github.com/adyen/adyen-openapi" class="card_item" data-track-component-name="card_item" data-track-section-title="diving further" data-track-title="openapi specifications" data-track-text="our latest api specifications, in openapi format" data-track-action="clicked" data-track-type="card_item">
+                    <a target="_blank" rel="noopener" href="https://github.com/adyen/adyen-openapi" class="card_item"
+                        data-track-component-name="card_item" data-track-section-title="diving further"
+                        data-track-title="openapi specifications"
+                        data-track-text="our latest api specifications, in openapi format" data-track-action="clicked"
+                        data-track-type="card_item">
                         <div class="card_item_top">
                             <div class="content">
                                 <img src="icons/api.svg" alt="" class="icon">
@@ -972,19 +1017,27 @@
                         </div>
                     </a>
 
-                    <a target="_blank" rel="noopener" href="https://www.adyen.com/blog/category/tech?utm_medium=referral&utm_source=developers.adyen.com" class="card_item" data-track-component-name="card_item" data-track-section-title="diving further" data-track-title="tech blog" data-track-text="deep dives into our tech stack" data-track-action="clicked" data-track-type="card_item">
+                    <a target="_blank" rel="noopener"
+                        href="https://www.adyen.com/knowledge-hub/articles?topics=1kgqEExzn0tr8RXaHk6Aqe?utm_medium=referral&utm_source=developers.adyen.com"
+                        class="card_item" data-track-component-name="card_item"
+                        data-track-section-title="diving further" data-track-title="knowledge hub"
+                        data-track-text="deep dives into our tech stack" data-track-action="clicked"
+                        data-track-type="card_item">
                         <div class="card_item_top">
                             <div class="content">
                                 <img src="icons/news.svg" alt="" class="icon">
-                                <h4 class="title">Tech Blog</h4>
+                                <h4 class="title">Knowledge Hub</h4>
                                 <div class="descrp">
                                     <p>Deep dives into our Tech Stack</p>
                                 </div>
                             </div>
                         </div>
                     </a>
-                    
-                    <a rel="noopener" href="newsletter-archive" class="card_item" data-track-component-name="card_item" data-track-section-title="diving further" data-track-title="our tech newsletter" data-track-text="monthly updates on new developer resources, new/existing products and events" data-track-action="clicked" data-track-type="card_item">
+
+                    <a rel="noopener" href="newsletter-archive" class="card_item" data-track-component-name="card_item"
+                        data-track-section-title="diving further" data-track-title="our tech newsletter"
+                        data-track-text="monthly updates on new developer resources, new/existing products and events"
+                        data-track-action="clicked" data-track-type="card_item">
                         <div class="card_item_top">
                             <div class="content">
                                 <img src="icons/news.svg" alt="" class="icon">
@@ -997,7 +1050,12 @@
                     </a>
 
 
-                    <a target="_blank" rel="noopener" href="https://www.adyen.com/payment-methods?utm_medium=referral&utm_source=developers.adyen.com" class="card_item" data-track-component-name="card_item" data-track-section-title="diving further" data-track-title="supported payment methods" data-track-text="an exhaustive list of our supported payment methods" data-track-action="clicked" data-track-type="card_item">
+                    <a target="_blank" rel="noopener"
+                        href="https://www.adyen.com/payment-methods?utm_medium=referral&utm_source=developers.adyen.com"
+                        class="card_item" data-track-component-name="card_item"
+                        data-track-section-title="diving further" data-track-title="supported payment methods"
+                        data-track-text="an exhaustive list of our supported payment methods"
+                        data-track-action="clicked" data-track-type="card_item">
                         <div class="card_item_top">
                             <div class="content">
                                 <img src="icons/library.svg" alt="" class="icon">
@@ -1009,7 +1067,11 @@
                         </div>
                     </a>
 
-                    <a target="_blank" rel="noopener" href="https://adyencheckout.com" class="card_item" data-track-component-name="card_item" data-track-section-title="diving further" data-track-title="adyen checkout create" data-track-text="interactive drop-in creation and styling tool" data-track-action="clicked" data-track-type="card_item">
+                    <a target="_blank" rel="noopener" href="https://adyencheckout.com" class="card_item"
+                        data-track-component-name="card_item" data-track-section-title="diving further"
+                        data-track-title="adyen checkout create"
+                        data-track-text="interactive drop-in creation and styling tool" data-track-action="clicked"
+                        data-track-type="card_item">
                         <div class="card_item_top">
                             <div class="content">
                                 <img src="icons/api.svg" alt="" class="icon">
@@ -1033,7 +1095,11 @@
                     <p>You ask, we answer.</p>
                 </div>
                 <div class="card">
-                    <a target="_blank" rel="noopener" href="https://stackoverflow.com/questions/tagged/adyen" class="card_item" data-track-component-name="card_item" data-track-section-title="knowledge base" data-track-title="stack overflow" data-track-text="asking technical questions and getting community answers" data-track-action="clicked" data-track-type="card_item">
+                    <a target="_blank" rel="noopener" href="https://stackoverflow.com/questions/tagged/adyen"
+                        class="card_item" data-track-component-name="card_item"
+                        data-track-section-title="knowledge base" data-track-title="stack overflow"
+                        data-track-text="asking technical questions and getting community answers"
+                        data-track-action="clicked" data-track-type="card_item">
                         <div class="card_item_top">
                             <div class="content">
                                 <img src="icons/stackoverflow.svg" alt="" class="icon">
@@ -1045,7 +1111,10 @@
                         </div>
                     </a>
 
-                    <a target="_blank" rel="noopener" href="https://twitter.com/adyendevs" class="card_item" data-track-component-name="card_item" data-track-section-title="knowledge base" data-track-title="adyendevs on twitter" data-track-text="our developer account on twitter" data-track-action="clicked" data-track-type="card_item">
+                    <a target="_blank" rel="noopener" href="https://twitter.com/adyendevs" class="card_item"
+                        data-track-component-name="card_item" data-track-section-title="knowledge base"
+                        data-track-title="adyendevs on twitter" data-track-text="our developer account on twitter"
+                        data-track-action="clicked" data-track-type="card_item">
                         <div class="card_item_top">
                             <div class="content">
                                 <img src="icons/twitter.svg" alt="" class="icon">
@@ -1057,7 +1126,11 @@
                         </div>
                     </a>
 
-                    <a target="_blank" rel="noopener" href="https://www.youtube.com/@adyendevs" class="card_item" data-track-component-name="card_item" data-track-section-title="knowledge base" data-track-title="adyendevs on youtube" data-track-text="our tech youtube channel with tutiorials on various topics" data-track-action="clicked" data-track-type="card_item">
+                    <a target="_blank" rel="noopener" href="https://www.youtube.com/@adyendevs" class="card_item"
+                        data-track-component-name="card_item" data-track-section-title="knowledge base"
+                        data-track-title="adyendevs on youtube"
+                        data-track-text="our tech youtube channel with tutiorials on various topics"
+                        data-track-action="clicked" data-track-type="card_item">
                         <div class="card_item_top">
                             <div class="content">
                                 <img src="icons/youtube.svg" alt="" class="icon">
@@ -1069,7 +1142,12 @@
                         </div>
                     </a>
 
-                    <a target="_blank" rel="noopener" href="https://help.adyen.com?utm_medium=referral&utm_source=developers.adyen.com" class="card_item" data-track-component-name="card_item" data-track-section-title="knowledge base" data-track-title="adyen help" data-track-text="the one location to get questions about our products answered" data-track-action="clicked" data-track-type="card_item">
+                    <a target="_blank" rel="noopener"
+                        href="https://help.adyen.com?utm_medium=referral&utm_source=developers.adyen.com"
+                        class="card_item" data-track-component-name="card_item"
+                        data-track-section-title="knowledge base" data-track-title="adyen help"
+                        data-track-text="the one location to get questions about our products answered"
+                        data-track-action="clicked" data-track-type="card_item">
                         <div class="card_item_top">
                             <div class="content">
                                 <img src="icons/help.svg" alt="" class="icon">
@@ -1084,8 +1162,8 @@
             </div>
         </section>
         <!-- Knowledge base end -->
-        
-        <!-- Logging In start --> 
+
+        <!-- Logging In start -->
         <section class="sect resources">
             <div class="container">
                 <div class="sect_header">
@@ -1093,7 +1171,11 @@
                     <p>Direct links to your various environments.</p>
                 </div>
                 <div class="card">
-                    <a target="_blank" rel="noopener" href="https://ca-live.adyen.com/ca/ca/login.shtml" class="card_item" data-track-component-name="card_item" data-track-section-title="logging in the customer area" data-track-title="live customer area" data-track-text="logging in your live environment" data-track-action="clicked" data-track-type="card_item">
+                    <a target="_blank" rel="noopener" href="https://ca-live.adyen.com/ca/ca/login.shtml"
+                        class="card_item" data-track-component-name="card_item"
+                        data-track-section-title="logging in the customer area" data-track-title="live customer area"
+                        data-track-text="logging in your live environment" data-track-action="clicked"
+                        data-track-type="card_item">
                         <div class="card_item_top">
                             <div class="content">
                                 <img src="icons/person-circle.svg" alt="" class="icon">
@@ -1105,7 +1187,11 @@
                         </div>
                     </a>
 
-                    <a target="_blank" rel="noopener" href="https://ca-test.adyen.com/ca/ca/login.shtml" class="card_item" data-track-component-name="card_item" data-track-section-title="logging in the customer area" data-track-title="test customer area" data-track-text="logging in your test environment" data-track-action="clicked" data-track-type="card_item">
+                    <a target="_blank" rel="noopener" href="https://ca-test.adyen.com/ca/ca/login.shtml"
+                        class="card_item" data-track-component-name="card_item"
+                        data-track-section-title="logging in the customer area" data-track-title="test customer area"
+                        data-track-text="logging in your test environment" data-track-action="clicked"
+                        data-track-type="card_item">
                         <div class="card_item_top">
                             <div class="content">
                                 <img src="icons/person-circle.svg" alt="" class="icon">
@@ -1117,25 +1203,35 @@
                         </div>
                     </a>
 
-                    <a target="_blank" rel="noopener" href="https://balanceplatform-live.adyen.com/balanceplatform" class="card_item" data-track-component-name="card_item" data-track-section-title="logging in the customer area" data-track-title="live balance platform" data-track-text="logging in your live environment for issuing, embedded financial products and afp" data-track-action="clicked" data-track-type="card_item">
+                    <a target="_blank" rel="noopener" href="https://balanceplatform-live.adyen.com/balanceplatform"
+                        class="card_item" data-track-component-name="card_item"
+                        data-track-section-title="logging in the customer area" data-track-title="live balance platform"
+                        data-track-text="logging in your live environment for issuing, embedded financial products and afp"
+                        data-track-action="clicked" data-track-type="card_item">
                         <div class="card_item_top">
                             <div class="content">
                                 <img src="icons/platforms.svg" alt="" class="icon">
                                 <h4 class="title">LIVE Balance Platform</h4>
                                 <div class="descrp">
-                                    <p>Logging in your LIVE environment for Issuing, Embedded Financial Products and Adyen for Platforms</p>
+                                    <p>Logging in your LIVE environment for Issuing, Embedded Financial Products and
+                                        Adyen for Platforms</p>
                                 </div>
                             </div>
                         </div>
                     </a>
 
-                    <a target="_blank" rel="noopener" href="https://balanceplatform-test.adyen.com/balanceplatform" class="card_item" data-track-component-name="card_item" data-track-section-title="logging in the customer area" data-track-title="test balance platform" data-track-text="logging in your test environment for issuing, embedded financial products and afp" data-track-action="clicked" data-track-type="card_item">
+                    <a target="_blank" rel="noopener" href="https://balanceplatform-test.adyen.com/balanceplatform"
+                        class="card_item" data-track-component-name="card_item"
+                        data-track-section-title="logging in the customer area" data-track-title="test balance platform"
+                        data-track-text="logging in your test environment for issuing, embedded financial products and afp"
+                        data-track-action="clicked" data-track-type="card_item">
                         <div class="card_item_top">
                             <div class="content">
                                 <img src="icons/platforms.svg" alt="" class="icon">
                                 <h4 class="title">TEST Balance Platform</h4>
                                 <div class="descrp">
-                                    <p>Logging in your TEST environment for Issuing, Embedded Financial Products and Adyen for Platforms</p>
+                                    <p>Logging in your TEST environment for Issuing, Embedded Financial Products and
+                                        Adyen for Platforms</p>
                                 </div>
                             </div>
                         </div>
@@ -1145,7 +1241,7 @@
             </div>
         </section>
         <!-- Logging in end -->
-        
+
     </main>
     <footer>
         <div class="container">
@@ -1167,4 +1263,5 @@
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-96FYZ2QBE7"></script>
 
 </body>
+
 </html>

--- a/index.html
+++ b/index.html
@@ -1020,13 +1020,13 @@
                     <a target="_blank" rel="noopener"
                         href="https://www.adyen.com/knowledge-hub/articles?topics=1kgqEExzn0tr8RXaHk6Aqe&utm_medium=referral&utm_source=developers.adyen.com"
                         class="card_item" data-track-component-name="card_item"
-                        data-track-section-title="diving further" data-track-title="knowledge hub"
+                        data-track-section-title="diving further" data-track-title="tech blog"
                         data-track-text="deep dives into our tech stack" data-track-action="clicked"
                         data-track-type="card_item">
                         <div class="card_item_top">
                             <div class="content">
                                 <img src="icons/news.svg" alt="" class="icon">
-                                <h4 class="title">Knowledge Hub</h4>
+                                <h4 class="title">Tech Blog</h4>
                                 <div class="descrp">
                                     <p>Deep dives into our Tech Stack</p>
                                 </div>

--- a/index.html
+++ b/index.html
@@ -1018,7 +1018,7 @@
                     </a>
 
                     <a target="_blank" rel="noopener"
-                        href="https://www.adyen.com/knowledge-hub/articles?topics=1kgqEExzn0tr8RXaHk6Aqe?utm_medium=referral&utm_source=developers.adyen.com"
+                        href="https://www.adyen.com/knowledge-hub/articles?topics=1kgqEExzn0tr8RXaHk6Aqe&utm_medium=referral&utm_source=developers.adyen.com"
                         class="card_item" data-track-component-name="card_item"
                         data-track-section-title="diving further" data-track-title="knowledge hub"
                         data-track-text="deep dives into our tech stack" data-track-action="clicked"


### PR DESCRIPTION
This PR replaces the link to the old Tech Blog with a new one to the Knowledge Hub.
Also, and just because I have a pre-commit hook configured, there are a lot of whitespaces adjustments.